### PR TITLE
Event type unit tests

### DIFF
--- a/src/components/NewTreatment.tsx
+++ b/src/components/NewTreatment.tsx
@@ -15,6 +15,7 @@ import { Month } from "../types/Date";
 import { range } from "../utility";
 import DetailValuesFactory from "../types/PatientEvent/Details/DetailValuesFactory";
 import { safelyParseInt } from "../utility/parseNumber";
+import DateField from "./form/DateField";
 
 export default function NewTreatment() {
   const { values, setFieldValue }: FormikValues = useFormikContext();
@@ -59,9 +60,7 @@ export default function NewTreatment() {
     <React.Fragment>
       <FilterSelect name='cancerType' label='Cancer Type' options={cancerTypeOptions} 
         displayValue={cancerTypeIndex(values.cancerType)?.cancerName ?? ''} />
-      <Select name='month' options={monthOptions} label='Month' displayValue={values.month} />
-      <Select name='day' label='Day' options={dayOptions} displayValue={values.day} />
-      <TextField name='year' filled={Boolean(values.year)} label='Year' />
+      <DateField name='date' label='Date' />
       <Select name='treatmentType' label='Treatment Type' options={treatmentTypeOptions} 
         displayValue={treatmentTypeIndex(values.treatmentType)?.treatmentName ?? ''} />
       <DetailFields />

--- a/src/components/form/DateField.tsx
+++ b/src/components/form/DateField.tsx
@@ -1,14 +1,12 @@
 import { Field } from "formik";
+import FieldLabel from "./FieldLabel";
 import FieldProps from "./FieldProps";
 
 export default function DateField(props: FieldProps) {
   return (
     <div>
       <Field type='date' name={props.name} id={props.name} autoComplete="off" />
-      <label htmlFor={props.name} className='filled'>
-        {props.label}
-        {<span className="error">{props.errors}</span>}
-      </label>
+      <FieldLabel {...props} filled={true} />
     </div>
   )
 }

--- a/src/components/form/DateField.tsx
+++ b/src/components/form/DateField.tsx
@@ -1,0 +1,14 @@
+import { Field } from "formik";
+import FieldProps from "./FieldProps";
+
+export default function DateField(props: FieldProps) {
+  return (
+    <div>
+      <Field type='date' name={props.name} id={props.name} autoComplete="off" />
+      <label htmlFor={props.name} className='filled'>
+        {props.label}
+        {<span className="error">{props.errors}</span>}
+      </label>
+    </div>
+  )
+}

--- a/src/components/form/FieldLabel.tsx
+++ b/src/components/form/FieldLabel.tsx
@@ -1,0 +1,15 @@
+import FieldProps from "./FieldProps";
+
+interface FieldLabelProps extends FieldProps {
+  filled?: boolean;
+  onClick?: () => void;
+}
+
+export default function FieldLabel(props: FieldLabelProps) {
+  return (
+    <label htmlFor={props.name} className={props.filled ? 'filled' : undefined} onClick={props.onClick}>
+      {props.label}
+      {<span className="error">{props.errors}</span>}
+    </label>
+  );
+}

--- a/src/components/form/FieldProps.ts
+++ b/src/components/form/FieldProps.ts
@@ -1,0 +1,5 @@
+export default interface FieldProps {
+  name: string,
+  label: string
+  errors?: string
+}

--- a/src/components/form/FilterSelect.tsx
+++ b/src/components/form/FilterSelect.tsx
@@ -4,6 +4,7 @@ import { FormikValues, useFormikContext } from "formik";
 import DropdownOption from "../../types/Form/Dropdown/DropdownOption";
 import { faSearch } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import FieldLabel from "./FieldLabel";
 
 
 interface SelectProps {
@@ -46,14 +47,9 @@ function SelectWrapper(props: SelectWrapperProps) {
           </li>
         ))}
       </ul>
-      <label 
-        htmlFor={props.name} 
-        className={values[props.name] !== undefined && values[props.name] !== '' ? 'filled' : undefined} 
-        onClick={handleOpen}
-      >
-        {props.label}
-        <span className="error">{errors[props.name]}</span>
-      </label>
+      <FieldLabel {...props} 
+        filled={![undefined, ''].includes(props.displayValue)} 
+        onClick={handleOpen} />
     </div>
   );
 }

--- a/src/components/form/TextField.tsx
+++ b/src/components/form/TextField.tsx
@@ -1,10 +1,8 @@
 import { Field } from "formik";
+import FieldProps from "./FieldProps";
 
-interface TextFieldProps {
-  name: string,
-  label: string
-  filled: boolean,
-  errors?: string
+interface TextFieldProps extends FieldProps {
+  filled?: boolean;
 }
 
 export default function TextField(props: TextFieldProps) {

--- a/src/components/form/TextField.tsx
+++ b/src/components/form/TextField.tsx
@@ -1,4 +1,5 @@
 import { Field } from "formik";
+import FieldLabel from "./FieldLabel";
 import FieldProps from "./FieldProps";
 
 interface TextFieldProps extends FieldProps {
@@ -9,9 +10,7 @@ export default function TextField(props: TextFieldProps) {
   return (
     <div>
       <Field name={props.name} id={props.name} autoComplete="off" />
-      <label htmlFor={props.name} className={props.filled ? 'filled' : undefined}>
-        {props.label}
-        {<span className="error">{props.errors}</span>}</label>
+      <FieldLabel {...props} />
     </div>
   )
 }

--- a/src/types/DB/JSON/Importer/StrictJSONImporter.ts
+++ b/src/types/DB/JSON/Importer/StrictJSONImporter.ts
@@ -16,9 +16,11 @@ export default abstract class StrictJSONImporter extends BaseJSONImporter  {
       if (typeof value === 'number') {
         return value;
       } else if (typeof value === 'string') {
-        try {
-          return parseFloat(value);
-        } catch (error) {};
+        const parsed: number = parseFloat(value);
+
+        if (!isNaN(parsed)) {
+          return parsed;
+        }
       }
       
       throw new Error('Invalid JSON number import');

--- a/src/types/DB/JSON/Importer/__test__/SafeJSONImporter.test.ts
+++ b/src/types/DB/JSON/Importer/__test__/SafeJSONImporter.test.ts
@@ -1,0 +1,49 @@
+import '@testing-library/jest-dom/extend-expect';
+import SafeJSONImporter from '../SafeJSONImporter';
+
+describe('SafeJSONImporter', () => {
+  it('imports a valid string', () => {
+    const value: string = 'valid string';
+    expect(SafeJSONImporter.importString(value)).toBe(value);
+  });
+
+  it('imports an invalid string', () => {
+    const value: number = 100;
+    expect(SafeJSONImporter.importString(value)).toBeUndefined();
+  });
+
+  it('imports a valid number', () => {
+    const value: number = 101;
+    expect(SafeJSONImporter.importNumber(value)).toBe(value);
+  });
+
+  it('imports a valid number string', () => {
+    const value: number = 10;
+    expect(SafeJSONImporter.importNumber(value.toString())).toBe(value);
+  });
+
+  it('imports an invalid number', () => {
+    const value: string = 'invalid';
+    expect(SafeJSONImporter.importNumber(value)).toBeUndefined();
+  });
+
+  it('imports a valid object', () => {
+    const value: Record<string, string> = { itemID: 'test' };
+    expect(SafeJSONImporter.importObject(value)).toStrictEqual(value);
+  });
+
+  it('imports an invalid object', () => {
+    const value: string[] = ['test', 'values'];
+    expect(SafeJSONImporter.importObject(value)).toBeUndefined();
+  });
+
+  it('imports a valid array', () => {
+    const value: string[] = ['test', 'array'];
+    expect(SafeJSONImporter.importArray(value)).toStrictEqual(value);
+  });
+
+  it('imports an invalid array', () => {
+    const value: Record<string, string> = { testID: 'id' };
+    expect(SafeJSONImporter.importArray(value)).toBeUndefined();
+  });
+});

--- a/src/types/DB/JSON/Importer/__test__/StrictJSONImporter.test.ts
+++ b/src/types/DB/JSON/Importer/__test__/StrictJSONImporter.test.ts
@@ -1,0 +1,49 @@
+import '@testing-library/jest-dom/extend-expect';
+import StrictJSONImporter from '../StrictJSONImporter';
+
+describe('StrictJSONImporter', () => {
+  it('imports a valid string', () => {
+    const value: string = 'valid string';
+    expect(StrictJSONImporter.importString(value)).toBe(value);
+  });
+
+  it('raises an error on an invalid string', () => {
+    const value: number = 100;
+    expect(() => StrictJSONImporter.importString(value)).toThrowError();
+  });
+
+  it('imports a valid number', () => {
+    const value: number = 101;
+    expect(StrictJSONImporter.importNumber(value)).toBe(value);
+  });
+
+  it('imports a valid number string', () => {
+    const value: number = 10;
+    expect(StrictJSONImporter.importNumber(value.toString())).toBe(value);
+  });
+
+  it('raises an error on an invalid number', () => {
+    const value: string = 'invalid';
+    expect(() => StrictJSONImporter.importNumber(value)).toThrowError();
+  });
+
+  it('imports a valid object', () => {
+    const value: Record<string, string> = { itemID: 'test' };
+    expect(StrictJSONImporter.importObject(value)).toStrictEqual(value);
+  });
+
+  it('raises an error on an invalid object', () => {
+    const value: string[] = ['test', 'values'];
+    expect(() => StrictJSONImporter.importObject(value)).toThrowError();
+  });
+
+  it('imports a valid array', () => {
+    const value: string[] = ['test', 'array'];
+    expect(StrictJSONImporter.importArray(value)).toStrictEqual(value);
+  });
+
+  it('raises an error on an invalid array', () => {
+    const value: Record<string, string> = { testID: 'id' };
+    expect(() => StrictJSONImporter.importArray(value)).toThrowError();
+  });
+});

--- a/src/types/DB/__test__/DBIndex.test.ts
+++ b/src/types/DB/__test__/DBIndex.test.ts
@@ -1,0 +1,35 @@
+import '@testing-library/jest-dom/extend-expect';
+
+import DBElement from '../DBElement';
+import DBIndex from '../DBIndex';
+
+interface TestElement extends DBElement {
+  name: string
+}
+
+describe('DBIndex', () => {
+  it('initializes the correct number of elements', () => {
+    const elements: TestElement[] = [
+      { id: 0, name: 'one' },
+      { id: 1, name: 'two' }
+    ];
+
+    const index = new DBIndex<TestElement>(elements);
+
+    expect(Object.keys(index)).toHaveLength(elements.length);
+  });
+
+  it('sets the correct index value for an element', () => {
+    const elements: TestElement[] = [
+      { id: 9, name: 'nine' },
+      { id: 3, name: 'three' }
+    ];
+
+    const index = new DBIndex<TestElement>(elements);
+
+    const testIndex: number = 1;
+    const testID: number = elements[testIndex].id;
+
+    expect(index[testID]).toBe(testIndex);
+  });
+});

--- a/src/types/Form/Dropdown/__test__/DropdownOption.test.ts
+++ b/src/types/Form/Dropdown/__test__/DropdownOption.test.ts
@@ -1,0 +1,18 @@
+import '@testing-library/jest-dom/extend-expect';
+import DropdownOption from '../DropdownOption';
+
+describe('DropdownOption', () => {
+  it('provides a label when specified', () => {
+    const label: string = 'test label';
+    const option = new DropdownOption('test key', label);
+
+    expect(option.getLabel()).toBe(label);
+  });
+  
+  it('provides a label with no label specified', () => {
+    const value: string = 'test';
+    const option = new DropdownOption(value);
+
+    expect(option.getLabel()).toBe(value);
+  });
+})


### PR DESCRIPTION
Add unit tests for basic Event types and utility types. Does not include tests for specific, dataclass-esque types where mocking is required.