### PR TITLE
Close dropdown on click outside

### DIFF
--- a/src/components/form/FilterSelect.tsx
+++ b/src/components/form/FilterSelect.tsx
@@ -27,6 +27,10 @@ function SelectWrapper(props: SelectWrapperProps) {
     setOpen(!open);
   }
 
+  function close() {
+    setOpen(false);
+  }
+
   function handleClickOption(event: MouseEvent, value: string | number) {
     event.stopPropagation();
 
@@ -35,7 +39,7 @@ function SelectWrapper(props: SelectWrapperProps) {
   }
 
   return (
-    <div className='select'>
+    <div className='select' onBlur={close} tabIndex={0}>
       <div onClick={handleOpen} id={props.name}>
         {(props.displayValue) || '\u00a0'}
       </div>


### PR DESCRIPTION
Uses `onBlur` to close dropdowns on any click outside the element.

Needed to specify `tabIndex` to allow focus on a `<div>` element. (This is usually reserved for `<input>` and related elements.)